### PR TITLE
Prevent errors when missing fields

### DIFF
--- a/src/handler/baseHandler.js
+++ b/src/handler/baseHandler.js
@@ -10,14 +10,19 @@ export class BaseHandler extends BaseService {
    * @param {*} cmd command to check
    */
   async check(cmd) {
-    const msg = await Message.findOne({ where: { id: cmd.dataValues.MessageId }});
-    const channel = await this.client.channels.get(msg.dataValues.channel);
-    const message = await channel.fetchMessage(msg.dataValues.id);
+    try {
+      const msg = await Message.findOne({ where: { id: cmd.dataValues.MessageId } });
+      const channel = await this.client.channels.get(msg.dataValues.channel);
+      const message = await channel.fetchMessage(msg.dataValues.id);
 
-    const isCommand = includes(this.options.commands, cmd.dataValues.name);
-    const isAllowed = !isEmpty(intersection(this.options.roles, message.member.roles.map((role) => role.name))) || isEmpty(this.options.roles) || this.options.roles === undefined;
+      const isCommand = includes(this.options.commands, cmd.dataValues.name);
+      const isAllowed = this.options.roles && message.member && !isEmpty(intersection(this.options.roles, message.member.roles.map((role) => role.name))) || isEmpty(this.options.roles) || this.options.roles === undefined;
 
-    return isCommand && isAllowed;
+      return isCommand && isAllowed;
+    } catch (err) {
+      console.log("Failed while checking operation");
+      return false;
+    }
   }
 
   /**
@@ -31,7 +36,7 @@ export class BaseHandler extends BaseService {
   }
 
   /**
-   * Gets command data by key 
+   * Gets command data by key
    * @param {*} cmd command to find data for
    * @param {*} key command data key
    */

--- a/src/handler/customCommandHandler.js
+++ b/src/handler/customCommandHandler.js
@@ -6,20 +6,22 @@ import { isNil, isEmpty, intersection } from 'lodash';
 
 export class CustomCommandHandler extends BaseHandler {
   async check(cmd) {
-    const msg = await Message.findOne({ where: { id: cmd.dataValues.MessageId }});
-    const channel = await this.client.channels.get(msg.dataValues.channel);
-    const message = await channel.fetchMessage(msg.dataValues.id);
+    try {
+      const msg = await Message.findOne({ where: { id: cmd.dataValues.MessageId } });
+      const channel = await this.client.channels.get(msg.dataValues.channel);
+      const message = await channel.fetchMessage(msg.dataValues.id);
 
-    const isCommand = !isNil(await CustomCommand.findOne({ where: { name: cmd.dataValues.name }}));
-    const isAllowed = !isEmpty(intersection(this.options.roles, message.member.roles.map((role) => role.name))) || isEmpty(this.options.roles) || this.options.roles === undefined;
-  
-    return isCommand && isAllowed;
+      const isCommand = !isNil(await CustomCommand.findOne({ where: { name: cmd.dataValues.name } }));
+      const isAllowed = this.options && message.member && !isEmpty(intersection(this.options.roles, message.member.roles.map((role) => role.name))) || isEmpty(this.options.roles) || this.options.roles === undefined;
+
+      return isCommand && isAllowed;
+    } catch (err) { return false; }
   }
 
   async handle(cmd) {
     const message = await Message.findOne({ where: { id: cmd.dataValues.MessageId }});
     const channel = message.dataValues.channel;
-    
+
     const customCommand = await CustomCommand.findOne({ where: { name: cmd.dataValues.name }});
 
     return await this.replyToChannel(channel, customCommand.dataValues.body);


### PR DESCRIPTION
Wrap access to fields in a try/catch block so the bot doesn't toss exceptions around when fields are missing in the data from discord.
